### PR TITLE
Resolve issue with readme installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Laravel-native implementation of the Model Context Protocol (MCP) Server, allo
 You can install the package via composer:
 
 ```bash
-composer require elliottlawson/laravel-mcp-server
+composer require elliottlawson/mcp-laravel-sdk
 ```
 
 The service provider will be automatically registered through Laravel's package discovery.


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the package name in the installation instructions to reflect the correct package name.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R10): Updated the package name in the composer installation command from `elliottlawson/laravel-mcp-server` to `elliottlawson/mcp-laravel-sdk`.